### PR TITLE
Fix rendering for markdown with frontmatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const htmlToText = require('html-to-text')
 module.exports = options => ({
   extendPageData($page) {
     try {
-      const { html } = $page._context.markdown.render($page._strippedContent)
+      const { html } = $page._context.markdown.render($page._content)
 
       const plaintext = htmlToText.fromString(html, {
         wordwrap: null,


### PR DESCRIPTION
The _content field should be used so that markdown with frontmatter can be rendered:

https://vuepress.vuejs.org/plugin/option-api.html#extendpagedata